### PR TITLE
rework ssh and threading to solve high cpu issue with ssh commands

### DIFF
--- a/fullcyclepy/backend/fcmapp.py
+++ b/fullcyclepy/backend/fcmapp.py
@@ -160,7 +160,7 @@ class ApplicationService:
     __logger_error = None
     antminer = None
 
-    def __init__(self, component=ComponentName.fullcycle, option=None):
+    def __init__(self, component=ComponentName.fullcycle, option=None, announceyourself = False):
         self.component = component
         self.initargs(option)
         self.startupstuff()
@@ -172,7 +172,8 @@ class ApplicationService:
         #this is slow. should be option to opt out of cache?
         self.initcache()
         self.init_application()
-        self.sendqueueitem(QueueEntry(QueueName.Q_LOG, '{0} Started {1}'.format(self.now(), self.component), QueueType.broadcast))
+        if announceyourself:
+            self.sendqueueitem(QueueEntry(QueueName.Q_LOG, '{0} Started {1}'.format(self.now(), self.component), QueueType.broadcast))
 
     def initargs(self, option):
         '''process command line arguments'''

--- a/fullcyclepy/helpers/antminerhelper.py
+++ b/fullcyclepy/helpers/antminerhelper.py
@@ -163,10 +163,16 @@ def restart(miner: Miner):
     return apiresponse
 
 def print_connection_data(connection):
-    print(connection.strdata)    # print the last line of received data
-    print('==========================')
-    print(connection.alldata)   # This contains the complete data received.
-    print('==========================')
+    if connection.strdata:
+        print(connection.strdata)    # print the last line of received data
+        print('==========================')
+    if connection.alldata:
+        print(connection.alldata)   # This contains the complete data received.
+        print('==========================')
+
+def print_response(response):
+    for line in response:
+        print(line)
 
 def getportfromminer(miner: Miner):
     if isinstance(miner.ftpport, int): return miner.ftpport
@@ -175,12 +181,19 @@ def getportfromminer(miner: Miner):
         if tryport > 0: return tryport
     return 22
 
+def getminerconfig(miner: Miner, login):
+    '''ger the miner config file'''
+    connection = Ssh(miner.ipaddress, login.username, login.password, port=getportfromminer(miner))
+    config = connection.exec_command('cat /config/{0}.conf'.format(getminerfilename(miner)))
+    connection.close_connection()
+    return config
+
 def restartminer(miner: Miner, login):
     '''restart miner through ssh'''
     connection = Ssh(miner.ipaddress, login.username, login.password, port=getportfromminer(miner))
     connection.open_shell()
     connection.send_shell('/etc/init.d/{0}.sh restart'.format(getminerfilename(miner)))
-    time.sleep(5)
+    time.sleep(15)
     print_connection_data(connection)
     connection.close_connection()
 
@@ -200,8 +213,7 @@ def reboot(miner: Miner, login):
     """ reboot the miner through ftp """
     connection = Ssh(miner.ipaddress, login.username, login.password, port=getportfromminer(miner))
     connection.open_shell()
-    connection.send_shell('/sbin/reboot')
-    time.sleep(5)
+    response = connection.exec_command('/sbin/reboot')
     print_connection_data(connection)
     connection.close_connection()
 

--- a/fullcyclepy/tests/test_miner.py
+++ b/fullcyclepy/tests/test_miner.py
@@ -1,19 +1,31 @@
 '''send command to miner'''
 
 from backend.fcmapp import ApplicationService, ComponentName
+from helpers.antminerhelper import getminerconfig, print_response
 
 APP = ApplicationService(ComponentName.fullcycle)
 
 MINER = APP.getminerbyname('TEST')
 MINER.ftpport = '22'
+
+response = getminerconfig(MINER, APP.sshlogin())
+print_response(response)
+
 ACCESS_ORIGINAL = APP.antminer.getaccesslevel(MINER)
+print('original', ACCESS_ORIGINAL)
 if ACCESS_ORIGINAL != 'restricted':
     APP.antminer.set_restricted(MINER)
     APP.antminer.waitforonline(MINER)
+
 ACCESS_RESTRICTED = APP.antminer.getaccesslevel(MINER)
+print('restricted', ACCESS_RESTRICTED)
 APP.antminer.set_privileged(MINER)
 APP.antminer.waitforonline(MINER)
+
 ACCESS_PRIVILEGED = APP.antminer.getaccesslevel(MINER)
+print('privileged', ACCESS_PRIVILEGED)
 #APP.antminer.restartssh(MINER)
 #APP.antminer.waitforonline(MINER)
+
 ACCESS_AFTERRESET = APP.antminer.getaccesslevel(MINER)
+input('press any key...')


### PR DESCRIPTION
This PR helps a lot. CPU does still spike when doing ssh but it comes down when the ssh shell session is released. Previously it was spiking to 99% and staying there which would cause the controller to become unusable.
I can see a need for reworking the ssh interaction with the miner, adding `with` to make sure resources get cleaned up. 
I noticed the access level will show `restricted` while miner is resetting. There needs to be better workflow around that scenario instead of using `waitformineronline`. That should be a separate task.
For now this is a big improvement.